### PR TITLE
Fix homepage padding and add some basic animations

### DIFF
--- a/styles/components/Navigation.module.scss
+++ b/styles/components/Navigation.module.scss
@@ -15,11 +15,19 @@
 
 	&__link {
 		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 
 	&__activelink {
 		text-decoration: none;
 		color: $blue;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 
 	&__button {

--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -7,4 +7,10 @@ button {
 	display: inline-block;
 	border-radius: 3.2rem;
 	background: none;
+	transition: all 0.2s;
+}
+
+button:hover {
+	box-shadow: 0.5rem 0.5rem 0.5rem $light-gray;
+	cursor: pointer;
 }

--- a/styles/pages/Home.module.scss
+++ b/styles/pages/Home.module.scss
@@ -4,6 +4,7 @@
 
 .home {
 	display: flex;
+	min-height: calc($rest-min-height - 10rem);
 }
 
 .homeleft {
@@ -11,7 +12,7 @@
 	display: flex;
 	justify-content: center;
 	gap: 1.6rem;
-	min-height: $rest-min-height;
+
 	flex-direction: column;
 
 	&__heading {
@@ -31,6 +32,5 @@
 	width: 50%;
 	display: flex;
 	align-items: center;
-	min-height: $rest-min-height;
 	justify-content: flex-end;
 }


### PR DESCRIPTION
This pull request is to add basic animations and fix the homepage padding so the height is the same as on the other pages.

To achieve this, I had to:
- Make button:hover animations
- Change button hover cursor to pointer
- Remove 10rem from home page height
- Add hover animation for navigation links for text underline