### PR TITLE
Change page padding, navigation gap and home job title

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ const Home: NextPage = () => {
 			<section className={styles.home}>
 				<section className={styles.homeleft}>
 					<h1 className={styles.homeleft__heading}>Joeri Breedveld</h1>
-					<h2 className={styles.homeleft__job}>Full-stack Developer</h2>
+					<h2 className={styles.homeleft__job}>Full Stack Developer</h2>
 					<button className={styles.homeleft__about} type="button" onClick={() => router.push("/about")}>
 						About Me
 					</button>

--- a/styles/abstracts/_mixins.scss
+++ b/styles/abstracts/_mixins.scss
@@ -6,6 +6,9 @@
 
 @mixin page-padding {
 	padding: $vert-padding $page-padding;
+	@media screen and (max-width: 768px) {
+		padding: $vert-padding 5vw;
+	}
 }
 
 @mixin center-content {

--- a/styles/abstracts/_variables.scss
+++ b/styles/abstracts/_variables.scss
@@ -10,3 +10,7 @@ $navigation-height: 10rem;
 $rest-min-height: calc(100vh - #{$navigation-height});
 $vert-padding: 3.2rem;
 $font: "Poppins", sans-serif;
+
+@media screen and (max-width: 768px) {
+	$page-padding: 0;
+}

--- a/styles/components/Navigation.module.scss
+++ b/styles/components/Navigation.module.scss
@@ -56,5 +56,9 @@
 		&__button {
 			display: none;
 		}
+
+		&__list {
+			gap: 0.8rem;
+		}
 	}
 }

--- a/styles/components/Skills.module.scss
+++ b/styles/components/Skills.module.scss
@@ -39,3 +39,16 @@
 		height: auto;
 	}
 }
+
+@media screen and (max-width: 768px) {
+	.skills {
+		&__list {
+			gap: 1.6rem;
+			flex-wrap: wrap;
+			justify-content: space-between;
+		}
+
+		&__listitem {
+		}
+	}
+}


### PR DESCRIPTION
This pull request if for the change of page padding, navigation gap and home job title.

To achieve this, I had to:
- Change page padding on media query to 5vw 
- Lower the navigation gap so it fits on the screen
- Change home job title to correct spelling